### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ function WeakmapEvent () {
   listen.toArray = createArrayListener(listen)
 
   return {
-    broadcast: broadcast,
-    listen: listen
+    broadcast,
+    listen
   }
 
   function broadcast (obj, value) {


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This syntax is supported in Node.js 4 and up. I was a bit unsure which was the minimum supported platform for this package, the `travis.yml` file indicated `iojs` so I downloaded that and tested and it works there too ✅ 